### PR TITLE
Refactor - bug fixes

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -1,105 +1,68 @@
 AbstractClientStore = require('express-brute/lib/AbstractClientStore')
 moment = require('moment')
-_ = require('underscore')
 Sequelize = require('sequelize')
 
-bruteStore = module.exports = (sequelize, table, options, callback) ->
-  AbstractClientStore.apply(this, arguments)
-  this.options = _.extend({}, bruteStore.defaults, options)
-  self = this
-  self._table = sequelize.define(table, {
-    _id:
-      type: Sequelize.STRING
-      unique: true
-    expires:
-      type: Sequelize.DATE
-    firstRequest:
-      type: Sequelize.DATE
-    lastRequest:
-      type: Sequelize.DATE
-    count:
-      type: Sequelize.INTEGER
-  })
+module.exports = class bruteStore
 
-  self._table.sync().then ->
-    if self.options.logging
-      console.log "bruteStore initialized - table #{table} created"
-    callback(self)
-  .catch ->
-    if self.options.logging
-      console.log "Failed to initialize bruteStore - table #{table}"
-    callback(self)
- 
-bruteStore.prototype = Object.create(AbstractClientStore.prototype)
+  constructor:(sequelize, table, options, callback) ->
+    AbstractClientStore.apply(@,arguments)
+    @options = Object.assign({}, bruteStore.defaults, options)
+    @_table = sequelize.define(table, {
+      _id: {type: Sequelize.STRING,unique: true}
+      expires: {type: Sequelize.DATE}
+      firstRequest: {type: Sequelize.DATE}
+      lastRequest: {type: Sequelize.DATE}
+      count: {type: Sequelize.INTEGER}
+    })
+    @defaults = {prefix: '',logging: false}
+    @_table.sync().then =>
+      console.log "bruteStore initialized - table #{table} created" if @options.logging
+      return callback(@)
+    .catch ->
+      console.log "Failed to initialize bruteStore - table #{table}" if @options.logging
+      return callback(@)
 
-bruteStore.prototype.set = (key, value, lifetime, callback) ->
-  self = this
-  _id = this.options.prefix+key
-  expiration = if lifetime then moment().add(lifetime, 'seconds').toDate() else null
+  set:(key, value, lifetime, callback) ->
+    _id = @options.prefix+key
+    expiration = if lifetime then moment().add(lifetime, 'seconds').toDate() else null
+    @_table.find(where:{_id:_id})
+    .then (doc)=>
+      if doc
+        doc._id = _id
+        doc.count = value.count
+        doc.lastRequest = value.lastRequest
+        doc.firstRequest = value.firstRequest
+        doc.expires = expiration
+        doc.save()
+      else
+        @_table.create(_id:_id,count:value.count,lastRequest:value.lastRequest,firstRequest:value.firstRequest,expires:expiration)
+    .then (doc) ->
+      typeof callback == 'function' && callback()
+      return null
+    .catch (err) ->
+      typeof callback == 'function' && callback(err)
+      return null
 
-  self._table.find
-    where:
-      _id: _id
-  .then (doc) ->
-    if doc
-      doc._id = _id
-      doc.count = value.count
-      doc.lastRequest = value.lastRequest
-      doc.firstRequest = value.firstRequest
-      doc.expires = expiration
-      doc.save().then ->
-        callback() if callback
-      .catch (err) ->
-        callback(err) if callback
-
-    else
-      self._table.create
-        _id: _id
-        count: value.count
-        lastRequest: value.lastRequest
-        firstRequest: value.firstRequest
-        expires: expiration
-      .then (doc) ->
-        callback() if callback
-      .catch (err) ->
-        callback(err) if callback
-
-  .catch (err) ->
-    callback(err) if callback
-
-bruteStore.prototype.get = (key, callback) ->
-  self = this
-  _id = this.options.prefix+key
-  self._table.find
-    where:
-      _id: _id
-  .then (doc) ->
-    data = {}
-    if doc && new Date(doc.expires).getTime() < new Date().getTime()
-      self._table.destroy
-        _id: _id
-      return callback()
-    if doc
-      data.count = doc.count
-      data.lastRequest = new Date(doc.lastRequest)
-      data.firstRequest = new Date(doc.firstRequest)
-      typeof callback == 'function' && callback(null, data)
-    else
-      typeof callback == 'function' && callback(null, null)
-  .catch (err) ->
-    typeof callback == 'function' &&  callback(err, null)
-
-bruteStore.prototype.reset = (key, callback) ->
-  self = this
-  _id = this.options.prefix+key
-  self._table.destroy
-    _id: _id
-  .then (doc) ->
-    typeof callback == 'function' && callback(null, doc)
-  .catch (err) ->
-    typeof callback == 'function' && callback(err, null)
-
-bruteStore.defaults = {
-  prefix: ''
-  logging: false
-}
+  get:(key, callback) ->
+    _id = @options.prefix+key
+    @_table.find(where:{_id:_id})
+    .then (doc) =>
+      return @_table.destroy(where:{_id: _id}) if doc && new Date(doc.expires).getTime() < new Date().getTime()
+      return Promise.resolve(count:doc.count,lastRequest:new Date(doc.lastRequest),firstRequest:new Date(doc.firstRequest)) if doc
+      Promise.resolve(null)
+    .then (data)-> 
+      typeof callback == 'function' &&  callback(null,data)
+      return null
+    .catch (err) ->
+      typeof callback == 'function' &&  callback(err, null)
+      return null
+    
+  reset:(key, callback) =>
+    _id = @options.prefix+key
+    @_table.destroy(where:{_id: _id})
+    .then (doc) ->
+      return typeof callback == 'function' && callback(null, doc)
+      return null
+    .catch (err) ->
+      return typeof callback == 'function' && callback(err, null)
+      return null


### PR DESCRIPTION
I noticed some bugs after my last pull request. Destroy wasn't working because sequelize now needs a `where` inside destroy. 

The promises are also complaining with this error - http://bluebirdjs.com/docs/warning-explanations.html#warning-a-promise-was-created-in-a-handler-but-was-not-returned-from-it so I've had to return null from those methods.

I've also refactored it into a coffee-script class and removed the underscore dependency with Object.assign (available since Node 0.12) 

I realise this is a big refactor, so if you don't accept the pull request I understand. On the plus side, it's 30 lines of code shorter and has removed a big dependency (haven't updated package.json)
